### PR TITLE
画像が縮んでるのでスタイル調整

### DIFF
--- a/src/components/Molecules/BlogItem/index.astro
+++ b/src/components/Molecules/BlogItem/index.astro
@@ -51,6 +51,7 @@ const WebpSrcset = `${imageWebp} 1x, ${imageWebp2x} 2x`
     &__eyecatch {
       img {
         width: 100%;
+        height: auto;
       }
     }
 


### PR DESCRIPTION
## 概要
ブログのアイキャッチが潰れてたのでスタイルで調整。

![スクリーンショット 2022-12-01 17 16 26](https://user-images.githubusercontent.com/30612104/205000975-47d1e1fe-2670-4fb2-ad3e-88e670304cc1.png)
